### PR TITLE
feat: treat .ng files as html files for better IDE support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.ng": "html",
+    },
+}


### PR DESCRIPTION
Currently the .ng files are not highlights anythings, treating .ng files as html gives better IDE support for now